### PR TITLE
Changing tools for cleaning generated javascript file

### DIFF
--- a/lib/constructs/certificate/index.ts
+++ b/lib/constructs/certificate/index.ts
@@ -97,14 +97,14 @@ export class SecretsManagerCertificate extends Construct {
             }
         })
 
-        const eventsRole = new iam.Role(this, 'EventsRole', {
-            assumedBy: new iam.ServicePrincipal('events.amazonaws.com'),
-        });
+        const eventsRole = new iam.Role(this, "EventsRole", {
+            assumedBy: new iam.ServicePrincipal("events.amazonaws.com"),
+        })
 
         rule.addTarget(new targets.SfnStateMachine(nomadCertStepfunction, {
             input: events.RuleTargetInput.fromObject({ }),
             role: eventsRole
-        }));
+        }))
     }
 
     private getLambdaRole(): iam.Role {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
     "nomad-edge-native": "bin/edge-native.js"
   },
   "scripts": {
-    "build": "npx eslint . && npx tsc && npx cdk synth",
+    "build": "npx eslint . && npx tsc --build --clean && npx cdk synth",
     "watch": "npx tsc -w",
     "test": "jest",
     "cdk": "npx cdk",
-    "nag": "npx cdk synth --app='npx ts-node test/edge-native.nag.ts'",
-    "clean": "find bin/ lib/ test/ -iname \"*.d.ts\" | xargs rm -f"
+    "nag": "npx cdk synth --app='npx ts-node test/edge-native.nag.ts'"
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",


### PR DESCRIPTION
ts-clean  was raising warning with the dependabot. So I removed it and replace it  by using `--clean` from the `tsc` command line
